### PR TITLE
Don't use loadSettings

### DIFF
--- a/LadderInterface.h
+++ b/LadderInterface.h
@@ -128,9 +128,9 @@ static void RunBot(int argc, char *argv[], sc2::Agent *Agent,sc2::Race race)
 	ParseArguments(argc, argv, Options);
 
 	sc2::Coordinator coordinator;
-	if (!coordinator.LoadSettings(argc, argv)) {
-		return;
-	}
+	// if (!coordinator.LoadSettings(argc, argv)) {
+	//	return;
+	// }
 
 	// Add the custom bot, it will control the players.
 	int num_agents;


### PR DESCRIPTION
We do not need to load the settings because all of this is already done in the ladderManager. Doing it anyway will pose problems on Linux systems because if started via wine it can't find the executable.

This should also take care of the annoying argument not found error.